### PR TITLE
Add LinkedIn lead generator button

### DIFF
--- a/src/content/generateLeads.ts
+++ b/src/content/generateLeads.ts
@@ -1,0 +1,14 @@
+export default function generateLeads(): void {
+  const selector = "button[aria-label='Load more comments']";
+
+  const clickUntilGone = (): void => {
+    const button = document.querySelector<HTMLButtonElement>(selector);
+    if (!button) {
+      return;
+    }
+    button.click();
+    setTimeout(clickUntilGone, 2000);
+  };
+
+  clickUntilGone();
+}

--- a/src/content/index.dev.tsx
+++ b/src/content/index.dev.tsx
@@ -11,6 +11,8 @@
 
 import { createRoot } from 'react-dom/client';
 
+import generateLeads from './generateLeads';
+
 import Content from './Content';
 
 import '@assets/styles/index.css';
@@ -33,3 +35,9 @@ document.body.appendChild(container);
 // Render the application inside the shadow root
 const root = createRoot(shadowRoot);
 root.render(<Content />);
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === 'generate-leads') {
+    generateLeads();
+  }
+});

--- a/src/content/index.prod.tsx
+++ b/src/content/index.prod.tsx
@@ -1,8 +1,16 @@
 import styles from '@assets/styles/index.css?inline';
 import createShadowRoot from '@utils/createShadowRoot';
 
+import generateLeads from './generateLeads';
+
 import Content from './Content';
 
 const root = createShadowRoot(styles);
 
 root.render(<Content />);
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === 'generate-leads') {
+    generateLeads();
+  }
+});

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,8 +1,24 @@
 import { JSX } from 'react';
 
 export default function Popup(): JSX.Element {
+  const handleGenerateLeads = () => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const activeTab = tabs[0];
+      if (activeTab?.id) {
+        chrome.tabs.sendMessage(activeTab.id, { type: 'generate-leads' });
+      }
+    });
+  };
+
   return (
-    <div id='my-ext' className='container' data-theme='light'>
+    <div id='my-ext' className='container space-y-2' data-theme='light'>
+      <button
+        type='button'
+        className='btn btn-primary w-full'
+        onClick={handleGenerateLeads}
+      >
+        Generate Leads from LinkedIn post
+      </button>
       <button type='button' className='btn btn-outline'>
         Default
       </button>


### PR DESCRIPTION
## Summary
- add generateLeads util for clicking LinkedIn's "Load more comments" button
- wire popup button to trigger content script
- listen for runtime messages in content scripts

## Testing
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/... )*
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/... )*

------
https://chatgpt.com/codex/tasks/task_e_685264253ff4832c8db3c255dc26e7ac